### PR TITLE
Fix database.yml parameter mistype

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ test:
 production:
   <<: *default
   adapter: mysql2
-  encoding: utf-8
+  encoding: utf8
   reconnect: true
   database: falae
   username: <%= ENV["DB_USER"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ test:
 production:
   <<: *default
   adapter: mysql2
-  encondig: utf-8
+  encoding: utf-8
   reconnect: true
   database: falae
   username: <%= ENV["DB_USER"] %>


### PR DESCRIPTION
Don't know if this actually caused any issues in production database but now it's written like it should be.