### PR TITLE
Fix account activation success flash

### DIFF
--- a/app/views/spreadsheets/index.html.erb
+++ b/app/views/spreadsheets/index.html.erb
@@ -1,3 +1,4 @@
+<%= render :partial => 'shared/flash'%>
 <%= render 'layouts/nav_menu_and_view' do %>
   <div class="spreadsheet">
     <% if notice %>


### PR DESCRIPTION
https://trello.com/c/QUiTmaUN/115-account-activation-success-flash-not-rendered