### PR TITLE
Unset current user when session expires

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -59,7 +59,9 @@ module SessionsHelper
   end
 
   def session_expired?
-    session[:expires_after] && session[:expires_after] < Time.now.to_i
+    expired = session[:expires_after] && session[:expires_after] < Time.now.to_i
+    log_out if expired
+    expired
   end
 
 end


### PR DESCRIPTION
This cause "Home" remains pointing to user spreadsheets path after the session has expired.