### PR TITLE
Fix - reset_session method is not available for views

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  before_action :session_expired?
+
   def home
   end
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <div class="session">
-    <% if logged_in? %>
+    <% if current_user %>
       <span class="welcome"><%= t 'views.welcome' %>, <%= link_to current_user.name,
             user_path(current_user), class: 'user-name' %>!</span>
       <span class="logout"><%= link_to logout_path, method: :delete do %>


### PR DESCRIPTION
If a user clicks "About" or "contact", there is a logic in headers partial that calls `logged_in?` method which check if his session has expired, if so, then `reset_session` gets called subsequently in a view context, since this method seems to be only available for controllers, a method undefined exception is raised.

This is a regression from #70 