### PR TITLE
Suport to Export/Import Boards and Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
-gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.15'
 
 # JQuery
 gem 'jquery-rails', '~> 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    bcrypt (3.1.11)
+    bcrypt (3.1.16)
     bindex (0.5.0)
     brakeman (4.1.0)
     builder (3.2.3)
@@ -229,7 +229,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt (~> 3.1.7)
+  bcrypt (~> 3.1.15)
   brakeman
   byebug
   coffee-rails (~> 4.2)

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -330,6 +330,21 @@ body {
       cursor: pointer;
       display: inline-block;
       padding: 4px;
+      user-select: none;
+
+      &:hover {
+        color: white;
+        background-color: $medium-sea-green;
+      }
+    }
+  }
+
+  .import-file {
+    text-align: left;
+    margin-top: 8px;
+
+    span {
+      padding-left: 4px;
     }
   }
 

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -172,6 +172,7 @@
 
     .add-button {
       background-color: white;
+      color: $dark-gray;
       font-size: 48px;
       padding: 0;
 
@@ -212,7 +213,9 @@
     }
   }
 
-  .edit-item, .search-item, .item-result {
+  .edit-item, .search-item, .item-result,
+  .export-page, .import,
+  .export-spreadsheet {
     background-color: white;
     margin: 2em auto;
     overflow: auto;
@@ -221,6 +224,10 @@
 
     .form-box {
       text-align: center;
+
+      #import {
+        text-align: left;
+      }
 
       .fields, .items {
         display: inline-block;
@@ -248,7 +255,7 @@
       }
     }
 
-    .item-title {
+    .item-title, .export-title, .import-title {
       color: $medium-sea-green;
       font-size: 1.5em;
       font-style: italic;

--- a/app/assets/stylesheets/spreadsheets.scss
+++ b/app/assets/stylesheets/spreadsheets.scss
@@ -6,8 +6,21 @@
 
 .spreadsheet {
 
-  .no-initial-page {
+  .no-initial-page, .no-file-selected {
     color: $dark-orange;
     font-style: italic;
+  }
+
+  #import-spreadsheet, #import-page {
+    text-align: left;
+  }
+
+  input[type=submit]:disabled {
+    background-color: $light-gray;
+    box-shadow: 0 0 0.25em 0.125px $light-gray;
+  }
+
+  input[type=submit]:hover {
+    opacity: 1;
   }
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -118,6 +118,19 @@ class PagesController < ApplicationController
     render locals: { item: item }
   end
 
+  # GET
+  def export
+    render locals: { filename: "#{@page.name}.#{t('.ext')}" }
+  end
+
+  # GET
+  def export_data
+    send_data @page.export(params[:include_private_items]),
+      disposition: :attachment,
+      filename: "#{@page.name}.#{t('.ext')}",
+      type: 'application/octetstream'
+  end
+
   # PUT
   def update_item
     return if item_params[:id].blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -103,6 +103,34 @@ class UsersController < ApplicationController
     end
   end
 
+
+  # GET /users/1/import_spreadsheet
+  def import_spreadsheet
+    render locals: { user: @user }
+  end
+
+  # POST /users/1/add_spreadsheet
+  def add_spreadsheet
+    file = params[:user][:spreadsheet_file]
+    if params[:user][:spreadsheet_file].blank?
+      render :update_spreadsheet_list,
+        locals: { error: t('.no_file') },
+        status: :bad_request
+      return
+    end
+
+    spreadsheet_encrypted = file.read
+    error = Spreadsheet.import spreadsheet_encrypted, @user
+    if !error
+      @spreadsheets = @user.spreadsheets
+      render :update_spreadsheet_list
+    else
+      render :update_spreadsheet_list,
+        locals: { error: error },
+        status: :unprocessable_entity
+    end
+  end
+
   private
   # Use callbacks to share common setup or constraints between actions.
   def set_user

--- a/app/models/item_page.rb
+++ b/app/models/item_page.rb
@@ -1,4 +1,6 @@
 class ItemPage < ApplicationRecord
   belongs_to :item
   belongs_to :page
+
+  after_destroy { item.destroy unless item.private?}
 end

--- a/app/models/spreadsheet.rb
+++ b/app/models/spreadsheet.rb
@@ -1,3 +1,5 @@
+require File.join(Rails.root, "lib", "encryption_service.rb")
+
 class Spreadsheet < ApplicationRecord
   belongs_to :user
   has_many :pages, dependent: :destroy
@@ -5,4 +7,57 @@ class Spreadsheet < ApplicationRecord
   # validates_associated :user
   validates :name, presence: true, uniqueness: { scope: :user }
   # TODO: validate existence of referenced initial_page when assign new value
+
+  def export_as_json
+    self.as_json(
+      only: [:name, :initial_page],
+      include: {
+        pages: {
+          only: [:name, :columns, :rows, :spreadsheet_id],
+          include: {
+            items: {
+              only: [:id, :name, :speech, :category_id],
+              include: {
+                image: {
+                  only: [:id, :type]
+                }
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  def export(include_private_items = false)
+    spreadsheet = self.export_as_json
+    if !include_private_items
+      spreadsheet['pages'].each do |page|
+        page['items'] = page['items'].select do |i|
+          i['image']['type'] != PrivateImage.name
+        end
+      end
+    end
+    EncryptionService.encrypt spreadsheet.to_json
+  end
+
+  def self.import(spreadsheet_encrypted, user)
+    spreadsheet_json = EncryptionService.decrypt spreadsheet_encrypted
+    parsed_spreadsheet = JSON.parse spreadsheet_json
+
+    Spreadsheet.transaction do
+      spreadsheet = Spreadsheet.create! name: parsed_spreadsheet['name'],
+        initial_page: parsed_spreadsheet['initial_page'],
+        user_id: user.id
+
+      parsed_spreadsheet['pages'].each do |page|
+        error = Page.import!(page, spreadsheet, spreadsheet.user, serialized: true)
+      end
+      nil
+    end
+  rescue ActiveSupport::MessageVerifier::InvalidSignature, JSON::ParserError => ex
+    I18n.t 'errors.invalid_file'
+  rescue ActiveRecord::RecordInvalid => ex
+    ex.message
+  end
 end

--- a/app/views/pages/_export.html.erb
+++ b/app/views/pages/_export.html.erb
@@ -1,0 +1,23 @@
+<div class="overlay">
+  <div class="export-page">
+    <a class="close">
+      <%= fa_icon 'times-circle-o', class: :default %>
+      <%= fa_icon 'times-circle', class: :hover %>
+    </a>
+    <p class="export-title"><%= t '.title' %></p>
+    <div class="form-box">
+      <%= form_with url: export_data_user_spreadsheet_page_path(@user, @spreadsheet, @page),
+          id: 'export-data' , method: :get do |form| %>
+        <div class="field">
+          <%= form.check_box :include_private_items, {}, true, false %>
+          <%= t('.include_private_items') %>
+        </div>
+        <div class="actions">
+          <%= form.button :submit, name: :export_data do %>
+            <%= t '.send' %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/export.js.erb
+++ b/app/views/pages/export.js.erb
@@ -1,0 +1,39 @@
+$('body').css('overflow', 'hidden');
+
+$("<%= escape_javascript(render 'pages/export') %>")
+  .appendTo(".pages");
+
+$('.overlay').show();
+
+function closeDialog(event) {
+  event.preventDefault();
+  $('.overlay').remove();
+  $('body').css('overflow', 'initial');
+  $(window).off('keyup', closeDialogOnEscape);
+}
+
+function closeDialogOnEscape (ev) {
+  if (ev.which === 27) {
+    closeDialog(ev);
+  }
+}
+
+$('#export-data').on('ajax:success', (ev) => {
+  const [data, status, xhr] = event.detail;
+  console.log(status, data)
+
+  const blob = new Blob([data], { type: "application/octetstream" });
+  const a = document.createElement('a');
+  const url = window.URL.createObjectURL(blob);
+  a.href = url;
+  a.download = "<%= filename %>";
+  document.body.append(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+
+  closeDialog(ev)
+});
+
+$('.close').on('click', closeDialog);
+$(window).on('keyup', closeDialogOnEscape);

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -15,14 +15,15 @@
       <%= fa_icon 'arrow-left' %><%= t '.back' %>
     <% end %>
 
+    <%= link_to export_user_spreadsheet_page_path(@user, @spreadsheet, @page),
+      class: 'button-box', remote: true do %>
+      <%= fa_icon 'upload' %><%= t '.export' %>
+    <% end %>
+
     <%= link_to pdf_user_spreadsheet_page_path(@user, @spreadsheet, @page, format: :pdf),
       class: 'button-box' do %>
       <%= fa_icon 'print' %><%= t '.print' %>
     <% end %>
-
-    <%#= link_to user_spreadsheet_page_items_path(@user, @spreadsheet, @page), class: 'button-box' do %>
-      <%#= fa_icon 'plus' %><%#= Add Item %>
-    <%# end %>
 
     <p>
       <strong><%= Page.human_attribute_name :name %>:</strong>

--- a/app/views/spreadsheets/_export.html.erb
+++ b/app/views/spreadsheets/_export.html.erb
@@ -1,0 +1,23 @@
+<div class="overlay">
+  <div class="export-spreadsheet">
+    <a class="close">
+      <%= fa_icon 'times-circle-o', class: :default %>
+      <%= fa_icon 'times-circle', class: :hover %>
+    </a>
+    <p class="item-title"><%= t '.title' %></p>
+    <div class="form-box">
+      <%= form_with url: user_spreadsheet_export_data_path(@user, @spreadsheet),
+          id: 'export-data' , method: :get do |form| %>
+        <div class="field">
+          <%= form.check_box :include_private_items, {}, true, false %>
+          <%= t('.include_private_items') %>
+        </div>
+        <div class="actions">
+          <%= form.button :submit, name: :export_data do %>
+            <%= t '.send' %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/spreadsheets/_import_page.html.erb
+++ b/app/views/spreadsheets/_import_page.html.erb
@@ -1,0 +1,26 @@
+<div class="overlay">
+  <div class="import">
+    <a class="close">
+      <%= fa_icon 'times-circle-o', class: :default %>
+      <%= fa_icon 'times-circle', class: :hover %>
+    </a>
+    <p class="import-title"><%= t '.title' %></p>
+    <div class="form-box">
+      <%= form_with model: spreadsheet, url: user_spreadsheet_add_page_path,
+        method: :post, html: {multipart: true}, id: "import-page" do |form| %>
+        <div class="field">
+          <%= form.label :select_file, t('.select_file') %>
+          <div class="wrapper-custom-input-file import-file">
+            <%= form.label 'page-file', t('.search'), class: 'custom-input-file' %>
+            <span id="selected-file" class="no-file-selected"><%= t '.no_file' %></span>
+            <%= form.file_field :page_file, id: 'page-file', class: 'hidden-file-field' %>
+          </div>
+        </div>
+
+        <div class="actions">
+          <%= form.submit t('.send'), id: 'page-file-submit', disabled: true %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/spreadsheets/export.js.erb
+++ b/app/views/spreadsheets/export.js.erb
@@ -1,0 +1,39 @@
+$('body').css('overflow', 'hidden');
+
+$("<%= escape_javascript(render 'spreadsheets/export') %>")
+  .appendTo(".spreadsheet");
+
+$('.overlay').show();
+
+function closeDialog(event) {
+  event.preventDefault();
+  $('.overlay').remove();
+  $('body').css('overflow', 'initial');
+  $(window).off('keyup', closeDialogOnEscape);
+}
+
+function closeDialogOnEscape (ev) {
+  if (ev.which === 27) {
+    closeDialog(ev);
+  }
+}
+
+$('#export-data').on('ajax:success', (ev) => {
+  const [data, status, xhr] = event.detail;
+  console.log(status, data)
+
+  const blob = new Blob([data], { type: "application/octetstream" });
+  const a = document.createElement('a');
+  const url = window.URL.createObjectURL(blob);
+  a.href = url;
+  a.download = "<%= filename %>";
+  document.body.append(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+
+  closeDialog(ev)
+});
+
+$('.close').on('click', closeDialog);
+$(window).on('keyup', closeDialogOnEscape);

--- a/app/views/spreadsheets/import_page.js.erb
+++ b/app/views/spreadsheets/import_page.js.erb
@@ -1,0 +1,53 @@
+$('body').css('overflow', 'hidden');
+
+$("<%= escape_javascript(render 'spreadsheets/import_page', spreadsheet: spreadsheet) %>")
+  .appendTo(".spreadsheet")
+
+$('.overlay').show();
+
+{
+  const importFileInput = document.getElementById('page-file');
+  importFileInput.addEventListener('change', ev => {
+    const file = ev.target.files[0];
+    if (file) {
+      const fileName = document.getElementById('selected-file');
+      fileName.classList.remove('no-file-selected');
+      const submitButton = document.getElementById('page-file-submit');
+      submitButton.disabled = false;
+      if ('textContent' in fileName) {
+        fileName.textContent = file.name;
+      } else {
+        fileName.innerText = file.name;
+      }
+    }
+  });
+}
+
+function closeDialog(event, preventDefault = true) {
+  if (preventDefault) {
+    event.preventDefault();
+  }
+  $('.overlay').remove();
+  $('body').css('overflow', 'initial');
+  $(window).off('keyup', closeDialogOnEscape);
+}
+
+function closeDialogOnEscape(ev) {
+  if (ev.which === 27) {
+    closeDialog(ev);
+  }
+}
+
+$('#import-page')
+  .on('ajax:before', (ev) => {
+    const loadingLayer = $('<div/>', {
+      id: 'paginate-loading-layer',
+      append: $('<div/>', {
+        class: 'fa fa-spinner fa-pulse fa-3x fa-fw',
+      })
+    }).appendTo($('body'));
+    closeDialog(ev, false);
+  });
+
+$('.close').on('click', closeDialog);
+$(window).on('keyup', closeDialogOnEscape);

--- a/app/views/spreadsheets/index.html.erb
+++ b/app/views/spreadsheets/index.html.erb
@@ -1,9 +1,12 @@
-<%= render :partial => 'shared/flash' %>
 <div class="spreadsheet">
   <% if notice %>
   <p id="notice"><%= notice %></p>
   <% end %>
   <div class="button-bar">
+    <%= link_to import_spreadsheet_user_path(@user),
+      class: 'button-box', remote: true do %>
+      <%= fa_icon 'download' %><%= t('.import') %>
+    <% end %>
     <%= link_to new_user_spreadsheet_path, class: 'button-box' do %>
       <%= fa_icon 'plus-circle' %><%= t '.new' %>
     <% end %>
@@ -11,6 +14,6 @@
   <% if @spreadsheets.present? %>
     <%= render 'spreadsheets/spreadsheet' %>
   <% else %>
-  <p><%= t '.none' %></p>
+  <p id='no-spreadsheet'><%= t '.none' %></p>
   <% end %>
 </div>

--- a/app/views/spreadsheets/show.html.erb
+++ b/app/views/spreadsheets/show.html.erb
@@ -11,6 +11,10 @@
   <%= link_to user_spreadsheets_path(@user), class: 'button-box' do %>
     <%= fa_icon 'arrow-left' %><%= t '.back' %>
   <% end %>
+  <%= link_to user_spreadsheet_export_path(@user, @spreadsheet),
+    class: 'button-box', remote: true do %>
+    <%= fa_icon 'upload' %><%= t '.export' %>
+  <% end %>
 
   <p>
     <strong><%= t Spreadsheet.human_attribute_name :name %>:</strong>
@@ -20,14 +24,19 @@
   <p>
     <strong><%= t Spreadsheet.human_attribute_name :initial_page %>:</strong>
     <% if @spreadsheet.initial_page.present? %>
-    <%= @spreadsheet.initial_page %>
+    <span class="initial-page-name"><%= @spreadsheet.initial_page %></span>
     <% else %>
-    <span class="no-initial-page"><%= t '.no_initial_page' %></span>
+    <span class="initial-page-name no-initial-page"><%= t '.no_initial_page' %></span>
     <% end %>
   </p>
 
+  <%= link_to user_spreadsheet_import_page_path(@user, @spreadsheet),
+    class: 'button-box', remote: true do %>
+    <%= fa_icon 'download' %><%= t '.import' %>
+  <% end %>
   <%= link_to new_user_spreadsheet_page_path(@user, @spreadsheet), class: 'button-box' do %>
     <%= fa_icon 'plus-circle' %><%= t '.new_page' %>
   <% end %>
+
   <%= render 'pages/page' %>
 </div>

--- a/app/views/spreadsheets/update_pages_list.js.erb
+++ b/app/views/spreadsheets/update_pages_list.js.erb
@@ -1,0 +1,15 @@
+$('#paginate-loading-layer').remove();
+
+<% if defined? error %>
+  alert("<%= t('.page_not_inported') %> <%= error %>");
+<% else %>
+  <% if initial_page %>
+    $(".initial-page-name")
+      .removeClass("no-initial-page")
+      .text("<%= initial_page %>");
+  <% end %>
+
+  $('.list').empty();
+  $("<%= escape_javascript(render 'pages/page') %>")
+    .appendTo(".spreadsheet");
+<% end%>

--- a/app/views/users/_import_spreadsheet.html.erb
+++ b/app/views/users/_import_spreadsheet.html.erb
@@ -1,0 +1,26 @@
+<div class="overlay">
+  <div class="import">
+    <a class="close">
+      <%= fa_icon 'times-circle-o', class: :default %>
+      <%= fa_icon 'times-circle', class: :hover %>
+    </a>
+    <p class="import-title"><%= t '.title' %></p>
+    <div class="form-box">
+      <%= form_with model: user, url: add_spreadsheet_user_path,
+        method: :post, html: {multipart: true}, id: "import-spreadsheet" do |form| %>
+        <div class="field">
+          <%= form.label :select_file, t('.select_file') %>
+          <div class="wrapper-custom-input-file import-file">
+            <%= form.label 'spreadsheet-file', t('.search'), class: 'custom-input-file' %>
+            <span id="selected-file" class="no-file-selected"><%= t '.no_file' %></span>
+            <%= form.file_field :spreadsheet_file, id: 'user_spreadsheet-file', class: 'hidden-file-field' %>
+          </div>
+        </div>
+
+        <div class="actions">
+          <%= form.submit t('.send'), id: 'spreadsheet-file-submit', disabled: true %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/import_spreadsheet.js.erb
+++ b/app/views/users/import_spreadsheet.js.erb
@@ -1,0 +1,53 @@
+$('body').css('overflow', 'hidden');
+
+$("<%= escape_javascript(render 'users/import_spreadsheet', user: user) %>")
+  .appendTo(".spreadsheet")
+
+$('.overlay').show();
+
+{
+  const importFileInput = document.getElementById('user_spreadsheet-file');
+  importFileInput.addEventListener('change', ev => {
+    const file = ev.target.files[0];
+    if (file) {
+      const fileName = document.getElementById('selected-file');
+      fileName.classList.remove('no-file-selected');
+      const submitButton = document.getElementById('spreadsheet-file-submit');
+      submitButton.disabled = false;
+      if ('textContent' in fileName) {
+        fileName.textContent = file.name;
+      } else {
+        fileName.innerText = file.name;
+      }
+    }
+  });
+}
+
+function closeDialog(event, preventDefault = true) {
+  if (preventDefault) {
+    event.preventDefault();
+  }
+  $('.overlay').remove();
+  $('body').css('overflow', 'initial');
+  $(window).off('keyup', closeDialogOnEscape);
+}
+
+function closeDialogOnEscape(ev) {
+  if (ev.which === 27) {
+    closeDialog(ev);
+  }
+}
+
+$('#import-spreadsheet')
+  .on('ajax:before', (ev) => {
+    const loadingLayer = $('<div/>', {
+      id: 'paginate-loading-layer',
+      append: $('<div/>', {
+        class: 'fa fa-spinner fa-pulse fa-3x fa-fw',
+      })
+    }).appendTo($('body'));
+    closeDialog(ev, false);
+  });
+
+$('.close').on('click', closeDialog);
+$(window).on('keyup', closeDialogOnEscape);

--- a/app/views/users/update_spreadsheet_list.js.erb
+++ b/app/views/users/update_spreadsheet_list.js.erb
@@ -1,0 +1,10 @@
+$('#paginate-loading-layer').remove();
+
+<% if defined? error %>
+  alert("<%= t('.spreadsheet_not_inported') %> <%= error %>");
+<% else %>
+  $('#no-spreadsheet').remove();
+  $('.list').empty();
+  $("<%= escape_javascript(render 'spreadsheets/spreadsheet') %>")
+    .appendTo(".spreadsheet");
+<% end%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
       year: Year
   errors:
     format: "%{attribute} %{message}"
+    invalid_file: 'Invalid file.'
     messages:
       accepted: must be accepted
       blank: can't be blank
@@ -295,7 +296,7 @@ en:
       contact: Contact
       home: Home
       log_in: Login
-      log_out: Sair
+      log_out: Logout
       register: Register
       welcome: Welcome
     nav_menu:
@@ -368,6 +369,7 @@ en:
       destroy: Delete
       destroy_alert: Deleting this page will also delete all of its pictograms.
       edit: Edit
+      export: Export
       mobile_view: Mobile view
       print: Print
     edit:
@@ -395,6 +397,13 @@ en:
     search_result:
       add_to_page: Add to page
       no_item_found: No item found.
+    export:
+      ext: page
+      include_private_items: Include page private items
+      send: Send
+      title: Export page
+    export_data:
+      ext: page
   password_resets:
     new:
       reset_password: Reset password
@@ -410,6 +419,7 @@ en:
       title: Crop Image
   spreadsheets:
     index:
+      import: Import
       new: New Board
       none: You don't have boards yet.
     new:
@@ -421,6 +431,8 @@ en:
       back: Back
       destroy: Delete
       edit: Edit
+      export: Export
+      import: Import
       new_page: New Page
       no_initial_page: '** Initial page not set **'
       destroy_alert: Deleting this board will also delete all of its pages and items.
@@ -431,6 +443,23 @@ en:
       notice: Board updated successfully.
     destroy:
       notice: Board deleted successfully.
+    add_page:
+      no_file: No file selected.
+    export:
+      ext: board
+      include_private_items: Include private items
+      send: Send
+      title: Export board
+    export_data:
+      ext: board
+    import_page:
+      no_file: No file selected.
+      send: Send
+      search: Search
+      select_file: 'Select file:'
+      title: Import page
+    update_page_list:
+      page_not_imported: It was not possible to import the page.
   support:
     array:
       last_word_connector: ", and "
@@ -482,6 +511,16 @@ en:
       incorrect_password: Current password is invalid.
       invalid_password: New password is invalid or not equal to confirmation password field.
       notice: Password updated successfully.
+    add_spreadsheet:
+      no_file: No file selected.
+    import_spreadsheet:
+      no_file: No file selected.
+      send: Send
+      search: Search
+      select_file: 'Select file:'
+      title: Import board
+    update_spreadsheet_list:
+      spreadsheet_not_inported: It was not possible to import the board.
   user_mailer:
     account_activation:
       activate: Activate

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -179,6 +179,7 @@ pt:
       year: Ano
   errors:
     format: "%{attribute} %{message}"
+    invalid_file: 'Arquivo inválido.'
     messages:
       accepted: deve ser aceito
       blank: não pode ficar em branco
@@ -368,6 +369,7 @@ pt:
       destroy: Apagar
       destroy_alert: Apagar esta página também apagará todos seus pictogramas.
       edit: Editar
+      export: Exportar
       mobile_view: Visualização de dispositivo
       print: Imprimir
     edit:
@@ -395,6 +397,13 @@ pt:
     search_result:
       add_to_page: Adicionar a página
       no_item_found: Nenhum item encontrado.
+    export:
+      ext: pagina
+      include_private_items: Incluir itens privados das páginas
+      send: Enviar
+      title: Exportar página
+    export_data:
+      ext: pagina
   password_resets:
     new:
       reset_password: Alterar senha
@@ -410,6 +419,7 @@ pt:
       title: Recortar Imagem
   spreadsheets:
     index:
+      import: Importar
       new: Criar Prancha
       none: Você ainda não possui nenhuma prancha.
     new:
@@ -421,6 +431,8 @@ pt:
       back: Voltar
       destroy: Apagar
       edit: Editar
+      export: Exportar
+      import: Importar
       new_page: Criar Página
       no_initial_page: '** Página inicial não definida **'
       destroy_alert: Apagar esta prancha também apagará todas suas páginas e itens.
@@ -431,6 +443,23 @@ pt:
       notice: Prancha atualizada com sucesso.
     destroy:
       notice: Prancha apagada com sucesso.
+    add_page:
+      no_file: Nenhum arquivo selecionado.
+    export:
+      ext: prancha
+      include_private_items: Incluir itens privados das páginas
+      send: Enviar
+      title: Exportar prancha
+    export_data:
+      ext: prancha
+    import_page:
+      no_file: Nenhum arquivo selecionado.
+      send: Enviar
+      search: Procurar
+      select_file: 'Selecionar arquivo:'
+      title: Importar página
+    update_page_list:
+      page_not_imported: Não foi possível importar a página.
   support:
     array:
       last_word_connector: " e "
@@ -482,6 +511,16 @@ pt:
       incorrect_password: A senha atual está incorreta.
       invalid_password: A nova senha é inválida ou não é igual ao campo confirmação de senha.
       notice: Senha atualizada com sucesso.
+    add_spreadsheet:
+      no_file: Nenhum arquivo selecionado.
+    import_spreadsheet:
+      no_file: Nenhum arquivo selecionado.
+      send: Enviar
+      search: Procurar
+      select_file: 'Selecionar arquivo:'
+      title: Importar prancha
+    update_spreadsheet_list:
+      spreadsheet_not_inported: Não foi possível importar a prancha.
   user_mailer:
     account_activation:
       activate: Ativar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,16 @@ Rails.application.routes.draw do
       get 'photo'
       get 'change_email'
       get 'change_password'
+      get 'import_spreadsheet'
+      post 'add_spreadsheet'
       patch 'update_email'
       patch 'update_password'
     end
     resources :spreadsheets do
+      get 'export'
+      get 'export_data'
+      get 'import_page'
+      post 'add_page'
       resources :pages do
         resources :items do
           member do
@@ -27,6 +33,8 @@ Rails.application.routes.draw do
         member do
           get 'add_item'
           get 'edit_item'
+          get 'export'
+          get 'export_data'
           get 'pdf'
           get 'search_item'
           post 'add_to_page'

--- a/lib/encryption_service.rb
+++ b/lib/encryption_service.rb
@@ -1,0 +1,26 @@
+class EncryptionService
+  KEY = ActiveSupport::KeyGenerator.new(
+      Rails.application.secrets.secret_key_base
+    ).generate_key(
+      Rails.application.secrets.secret_key_base,
+      ActiveSupport::MessageEncryptor.key_len
+    ).freeze
+
+  private_constant :KEY
+
+  delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
+
+  def self.encrypt (value)
+    new.encrypt_and_sign(value)
+  end
+
+  def self.decrypt(value)
+    new.decrypt_and_verify(value)
+  end
+
+  private
+
+  def encryptor
+    ActiveSupport::MessageEncryptor.new(KEY)
+  end
+end

--- a/lib/tasks/falae.rake
+++ b/lib/tasks/falae.rake
@@ -1,0 +1,15 @@
+namespace :falae do
+  desc 'Restart Falae App'
+  task restart: :environment do
+    system("kill -9 $(cat #{Rails.root}/tmp/pids/puma.pid)")
+    system('bundle exec puma -e production -d')
+  end
+
+  desc 'Bundle install'
+  task bundle_install: :environment do
+    system('bundle install')
+  end
+
+  desc 'Bundle install, assets precompile, and restart'
+  task restart_after_deploy: [:environment, 'falae:bundle_install', 'assets:precompile', 'falae:restart']
+end

--- a/lib/tasks/puma.rake
+++ b/lib/tasks/puma.rake
@@ -1,7 +1,0 @@
-namespace :puma do
-  desc 'Restart server'
-  task restart: :environment do
-    system("kill -9 $(cat #{Rails.root}/tmp/pids/puma.pid)")
-    system('bundle exec puma -e production -d')
-  end
-end


### PR DESCRIPTION
Support for Exporting/Importing boards and pages.

- User can choose if he wants to include private items present in pages;
- Basic error handling (model validations, network errors ...);
- Exported file is encrypted, so it will not expose id's.

Sample:
![export-import](https://user-images.githubusercontent.com/3502320/123421380-22760200-d593-11eb-9a4c-569a000a54d5.gif)


